### PR TITLE
Support for shell-compatible .env files 

### DIFF
--- a/spec/data/connect.env
+++ b/spec/data/connect.env
@@ -1,0 +1,6 @@
+DB_HOST=dwh.example.com
+DB_NAME=archive
+DB_PASS="Copper's1r0n"
+DB_LOGIN=Daedalus
+ON_CONN=' UPDATE status SET value="connected" WHERE user="Daedalus" '
+ON_DISCON=' UPDATE status SET value="disconnected" WHERE user="Daedalus" '

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -2,8 +2,8 @@ require "./spec_helper"
 
 describe Dotenv do
   # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
+  it "correctly parses values containing nested quotes and leading/trailing spaces" do
+    conf = Dotenv.load("spec/data/connect.env")
+    conf["ON_CONN"].should eq %( UPDATE status SET value="connected" WHERE user="Daedalus" )
   end
 end


### PR DESCRIPTION
Hi!
I did some rewrite of your process_file to add support for .env files which can be sourced from Bash, ZSH, etc. scripts to be possibble to use the same config files in system-wide administrative scripts and in crystal code as well. 