### PR TITLE
Fix: backslashed symbols extrapolaion

### DIFF
--- a/spec/data/connect.env
+++ b/spec/data/connect.env
@@ -1,6 +1,9 @@
-DB_HOST=dwh.example.com
-DB_NAME=archive
+DB_HOST=mus-db.example.com
+DB_DESCR=musical\ archive\ \"The\ best\ of\ XX\'th\ century\ music\" 
+DB_NAME=mus_archive
 DB_PASS="Copper's1r0n"
 DB_LOGIN=Daedalus
 ON_CONN=' UPDATE status SET value="connected" WHERE user="Daedalus" '
 ON_DISCON=' UPDATE status SET value="disconnected" WHERE user="Daedalus" '
+DBL_QUOTED=" Double \\\"quoted\" string"
+TOP_SONG=Mambo#5

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -12,10 +12,12 @@ module Dotenv
     File.read_lines( File.expand_path path )
       .reject { |line| line =~ /^\s*(?:#.*)?$/ }
       .map    { |line|
-        if line.match(/^([^#=\s]+)\s*=\s*(?:(?<Q>["'`])((?:(?!\k<Q>|\\).|\\.)*)\k<Q>)(?:\s+(?:#.*)?)?$/)
-          {$1, $3}
-        elsif line.match(/^([^#=\s]+)\s*=\s*([^#\s"']+)(?:\s+(?:#.*)?)?/)
-          {$1, $2}
+        if line.match(/^([^#=\s]+)=(?:(?<Q>["`])((?:(?!\k<Q>|\\).|\\.)*)\k<Q>)(?:\s+(?:#.*)?)?$/)
+          { $1, $3.gsub(Regex.new(%q<\\.>)) {|s| s[-1]} }
+        elsif line.match(/^([^#=\s]+)='([^']+)'(?:\s+(?:#.*)?)?$/)
+          { $1, $2 }
+        elsif line.match(/^([^#=\s]+)=([^#\s"'](?:[^\s"']|\\.)*)(?:\s+(?:#.*)?)?$/)
+          { $1, $2.gsub(Regex.new(%q<\\.>)) {|s| s[-1]} }
         else
           raise "this line in the env file #{path} was formatted incorrectly: #{line}"
         end


### PR DESCRIPTION
My previous version of process_file works incorrectly with strings containing backslashes but not enclosed in single quotes: backslashes was noe removed from the resulting strings.
Now it is fixed.
The second change: a = b finally considered unsupported (Shell cant work with such assignments)  