### PR TITLE
Skip existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ require "dotenv"
 Dotenv.load(path: ".env.live")
 ```
 
+### Overriding
+
+By default the existing environment will be overriden by contents of the .env file. To disable this behaviour pass false to override_env parameter:
+```crystal
+require "dotenv"
+
+hash = Dotenv.load(override_env: false)
+```
+
 ## Development
 
 TODO: Write development instructions here

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -6,4 +6,18 @@ describe Dotenv do
     conf = Dotenv.load("spec/data/connect.env")
     conf["ON_CONN"].should eq %( UPDATE status SET value="connected" WHERE user="Daedalus" )
   end
+
+  describe "#load" do
+    it "overrides existing environment variables by default" do
+      ENV["DB_HOST"] = "example.com"
+      Dotenv.load("spec/data/connect.env")
+      ENV["DB_HOST"].should eq "mus-db.example.com"
+    end
+
+    it "skips existing environment variables when requested" do
+      ENV["DB_HOST"] = "example.com"
+      Dotenv.load("spec/data/connect.env", override_env: false)
+      ENV["DB_HOST"].should eq "example.com"
+    end
+  end
 end

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -1,8 +1,8 @@
 module Dotenv
-  def self.load(path = ".env", set_env = true) : Hash(String, String)
+  def self.load(path = ".env", set_env = true, override_env = true) : Hash(String, String)
     hash = process_file(path)
     if set_env
-      set_env(hash)
+      set_env(hash, override_env)
     end
 
     hash
@@ -24,9 +24,11 @@ module Dotenv
       }.to_h
   end
 
-  private def self.set_env(hash : Hash(String, String))
+  private def self.set_env(hash : Hash(String, String), override_env : Bool)
     hash.each do |key, value|
-      ENV[key] = value
+      if !ENV.has_key?(key) || override_env
+        ENV[key] = value
+      end
     end
   end
 end


### PR DESCRIPTION
Numerous .env libraries don't set variables which are already set when the file is loaded. This is to allow overriding parts of the .env file with local customizations. For example from [motdotla/dotenv](https://github.com/motdotla/dotenv#what-happens-to-environment-variables-that-were-already-set):

> We will never modify any environment variables that have already been set. In particular, if there is a variable in your .env file which collides with one that already exists in your environment, then that variable will be skipped.

This patch provides a way of not touching the env. To provide backward compatibility the flag is disabled by default.