### PR TITLE
Treat a non-existent dotenv file as an empty one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # dotenv
 
-Loads .env file in Crystal and optionally loads them directly into your ENV var: https://crystal-lang.org/api/0.27.0/ENV.html  
-Will always return the .env file as a hash regardless of whether you chose to load into your ENV or not
+Loads a .env file in Crystal and optionally sets values directly into your [ENV](https://crystal-lang.org/api/latest/ENV.html).
+Will always return the .env file as a hash regardless of whether you chose to load into your `ENV` or not. Will treat a non-existent
+.env file as an empty one.
 
 ## Installation
 
@@ -34,21 +35,21 @@ DB_PORT=3306
 DB_DATABASE=test
 ```
 
-##### Using a file called .env and loading into your ENV var
+##### Using a file called .env and loading into your `ENV`
 ```crystal
 require "dotenv"
 
 Dotenv.load # => {"ENV" => "dev", "PORT" => "3000", "LOGGING" => "true", "CORS" => "*", "DB_DRIVER" => "mysql", "DB_USERNAME" => "root", "DB_PASSWORD" => "password", "DB_HOST" => "localhost", "DB_PORT" => "3306", "DB_DATABASE" => "test"}
 ```
 
-##### Using a file called .env and NOT loading into your ENV var
+##### Using a file called .env and NOT loading into your `ENV`
 ```crystal
 require "dotenv"
 
 hash = Dotenv.load(set_env: false)
 ```
 
-##### Using a file NOT called .env and loading into your ENV var
+##### Using a file NOT called .env and loading into your `ENV`
 ```crystal
 require "dotenv"
 
@@ -66,7 +67,10 @@ hash = Dotenv.load(override_env: false)
 
 ## Development
 
-TODO: Write development instructions here
+1. Clone the repository: `git clone git@github.com:drum445/dotenv.git`.
+   There are no dependencies, so no `shards install` is needed (but won't do any harm).
+3. Change into the project root directory: `cd dotenv`.
+2. Run specs: `crystal spec`.
 
 ## Contributing
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: dotenv
-version: 0.4.0
+version: 0.5.0
 
 authors:
   - drum445 <humdrum375@gmail.com>

--- a/spec/data/empty.env
+++ b/spec/data/empty.env
@@ -1,0 +1,1 @@
+# An empty .env file

--- a/spec/dotenv_spec.cr
+++ b/spec/dotenv_spec.cr
@@ -19,5 +19,13 @@ describe Dotenv do
       Dotenv.load("spec/data/connect.env", override_env: false)
       ENV["DB_HOST"].should eq "example.com"
     end
+
+    it "produces an empty hash with an empty dotenv file" do
+      Dotenv.load("spec/data/empty.env").should eq Hash(String, String).new
+    end
+
+    it "produces an empty hash with a non-existent dotenv file" do
+      Dotenv.load("no/such/path.env").should eq Hash(String, String).new
+    end
   end
 end

--- a/src/dotenv.cr
+++ b/src/dotenv.cr
@@ -1,11 +1,11 @@
 module Dotenv
   def self.load(path = ".env", set_env = true, override_env = true) : Hash(String, String)
     hash = process_file(path)
-    if set_env
-      set_env(hash, override_env)
-    end
+    set_env(hash, override_env) if set_env
 
     hash
+  rescue exc : File::NotFoundError
+    Hash(String, String).new
   end
 
   private def self.process_file(path : String)


### PR DESCRIPTION
A dotenv file should complement the environment, that is, variables from the dotenv are merged with the `ENV` settings, with a fine control over a) value overriding and b) changing the environment. This is the current behavior and it should be preserved.

About the case of a _missing dotenv file_: this should be treated as an _empty_ dotenv and _not_ raise an error, but produce an outcome equal to the one of an _empty_ dotenv. This is the change proposed here.

(In addition, reflecting the above change into the README + some minor improvements.)